### PR TITLE
Use proxy-conf on ng serve, so that using npm run start is not necess…

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -4,7 +4,7 @@ This project was generated with [Angular CLI](https://github.com/angular/angular
 
 ## Development server
 
-Run `npm start` for a dev server. Navigate to `http://localhost:4200/`. The app will automatically reload if you change any of the source files.
+Run `ng serve` for a dev server. Navigate to `http://localhost:4200/`. The app will automatically reload if you change any of the source files.
 
 ## Code scaffolding
 

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -71,7 +71,8 @@
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
           "options": {
-            "browserTarget": "crms-frontend:build"
+            "browserTarget": "crms-frontend:build",
+            "proxyConfig": "./proxy.conf.json"
           },
           "configurations": {
             "production": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve --proxy-config proxy.conf.json",
+    "start": "ng serve",
     "build": "ng build",
     "test": "ng test",
     "lint": "ng lint",


### PR DESCRIPTION
Aktuell muss man das Frontend mit "npm run start" starten, oder muss beim ng-serve die proxy-config als Parameter mitgeben, damit die Backend-Anbindung korrekt funktioniert.

Das ist nicht sehr intuitiv und hat schon öfter zu Problemen geführt, daher habe ich jetzt die proxy-config als Standardoption für ng serve hinterlegt, sodass wieder das normale "ng serve" zum Starten des Frontends genutzt werden kann.

