### PR TITLE
ram_bugfix_kal

### DIFF
--- a/frontend/src/app/calendar/calendar.component.ts
+++ b/frontend/src/app/calendar/calendar.component.ts
@@ -90,7 +90,7 @@ export class CalendarComponent implements OnInit {
     private jwt: JwtService,
     private translate: TranslationService) {}
 
-  activeDayIsOpen = true;
+  activeDayIsOpen = false;
 
   dayClicked({ date, events }: { date: Date; events: CalendarEvent[] }): void {
     if (isSameMonth(date, this.viewDate)) {
@@ -187,6 +187,7 @@ export class CalendarComponent implements OnInit {
         );
         idx++;
       });
+      this.refresh.next();
     });
   }
 

--- a/frontend/src/app/contacts/contacts-list/contacts-list.component.html
+++ b/frontend/src/app/contacts/contacts-list/contacts-list.component.html
@@ -28,13 +28,13 @@
     <mat-table id="contactsTable" #table [dataSource]="dataSource">
         <ng-container matColumnDef="icon">
             <mat-header-cell *matHeaderCellDef>
-                <mat-checkbox [checked]="isAllSelected" (change)="changeSelectionAll()"></mat-checkbox>
+                <mat-checkbox color="primary" [checked]="isAllSelected" (change)="changeSelectionAll()"></mat-checkbox>
             </mat-header-cell>
             <mat-cell *matCellDef="let element" (mouseover)="mouseOver(element.id)">
                 <div *ngIf="!isSelectedRow(element.id)" class="selection">
                     {{element.preName.substring(0,1) + element.name.substring(0,1)}}
                 </div>
-                <mat-checkbox class="checkBox" *ngIf="isSelectedRow(element.id)"
+                <mat-checkbox color="primary" class="checkBox" *ngIf="isSelectedRow(element.id)"
                     [checked]="isSelectionChecked(element.id)" (change)="onCheckBoxChecked(element.id)">
                 </mat-checkbox>
             </mat-cell>

--- a/frontend/src/app/events/events-detail/events-detail.component.html
+++ b/frontend/src/app/events/events-detail/events-detail.component.html
@@ -68,13 +68,13 @@
         </mat-chip-list>
         <mat-autocomplete #autoComplete="matAutocomplete">
             <mat-option>
-                <mat-checkbox id="contactInput" [checked]="isAllSelected" (change)="toggleSelectAll()" (click)="$event.stopPropagation()">
+                <mat-checkbox color="primary" id="contactInput" [checked]="isAllSelected" (change)="toggleSelectAll()" (click)="$event.stopPropagation()">
                         {{'common.selectAll' | translate}}
                 </mat-checkbox>
             </mat-option>
             <mat-option *ngFor="let item of filteredItems" [value]="selectedItems">
                 <div (click)="optionClicked($event, item);">
-                    <mat-checkbox [checked]="item.selected" (change)="toggleSelection(item)" (click)="$event.stopPropagation()">
+                    <mat-checkbox color="primary" [checked]="item.selected" (change)="toggleSelection(item)" (click)="$event.stopPropagation()">
                         {{ item.preName + ' ' + item.name }}
                     </mat-checkbox>
                 </div>

--- a/frontend/src/app/events/events-detail/events-detail.component.scss
+++ b/frontend/src/app/events/events-detail/events-detail.component.scss
@@ -36,3 +36,4 @@
 .marginTop {
   margin-top: 20px;
 }
+

--- a/frontend/src/app/events/events-list/events-list.component.html
+++ b/frontend/src/app/events/events-list/events-list.component.html
@@ -7,7 +7,7 @@
             <mat-label>{{'common.search' | translate}}</mat-label>
             <input matInput (keyup)="applyFilter($event)" placeholder="{{'event.events' | translate }}...">
         </mat-form-field>
-        <mat-checkbox class="button" [checked]="checkboxSelected" title="{{'event.hidePast' | translate}}"
+        <mat-checkbox color="primary" class="button" [checked]="checkboxSelected" title="{{'event.hidePast' | translate}}"
             (change)="toggleSelection()">
             {{'event.hidePast' | translate}}
         </mat-checkbox>

--- a/frontend/src/app/events/events-list/events-list.component.html
+++ b/frontend/src/app/events/events-list/events-list.component.html
@@ -26,18 +26,18 @@
     <mat-table mat-table [dataSource]="dataSourceFiltered">
         <ng-container matColumnDef="bezeichnung">
             <mat-header-cell *matHeaderCellDef> {{'common.label' | translate}} </mat-header-cell>
-            <mat-cell [ngStyle]="{'background-color': isToday(element) ? 'blue' : ''}" *matCellDef="let element">
+            <mat-cell (click)="openInfo(element.id)" [ngStyle]="{'background-color': isToday(element) ? 'blue' : ''}" *matCellDef="let element">
                 {{element.name}}
             </mat-cell>
         </ng-container>
         <ng-container matColumnDef="datum">
             <mat-header-cell *matHeaderCellDef> {{'common.date' | translate}} </mat-header-cell>
-            <mat-cell [ngStyle]="{'background-color': isToday(element) ? 'blue' : ''}" *matCellDef="let element">
+            <mat-cell (click)="openInfo(element.id)" [ngStyle]="{'background-color': isToday(element) ? 'blue' : ''}" *matCellDef="let element">
                 {{element.date | date:'dd-MM-yyyy'}} </mat-cell>
         </ng-container>
         <ng-container matColumnDef="uhrzeit">
             <mat-header-cell *matHeaderCellDef> {{'common.time' | translate}} </mat-header-cell>
-            <mat-cell [ngStyle]="{'background-color': isToday(element) ? 'blue' : ''}" *matCellDef="let element">
+            <mat-cell (click)="openInfo(element.id)" [ngStyle]="{'background-color': isToday(element) ? 'blue' : ''}" *matCellDef="let element">
                 {{element.time | date:'HH:mm:ss'}} </mat-cell>
         </ng-container>
         <ng-container matColumnDef="action">

--- a/frontend/src/app/events/events-list/events-list.component.ts
+++ b/frontend/src/app/events/events-list/events-list.component.ts
@@ -162,7 +162,7 @@ export class EventsListComponent implements OnInit {
 
   callEdit(id: number) {
     this.service.getById(id).subscribe(x => {
-      const dialogRef = this.dialog.open(EventsDetailComponent, { data: x, disableClose: true, minWidth: '450px', height: '600px' });
+      const dialogRef = this.dialog.open(EventsDetailComponent, { data: x, disableClose: true, minWidth: '450px', height: '800px' });
       dialogRef.afterClosed().subscribe(y => this.init());
     });
   }

--- a/frontend/src/app/organizations/organizations-edit-dialog/organizations-edit-dialog.component.html
+++ b/frontend/src/app/organizations/organizations-edit-dialog/organizations-edit-dialog.component.html
@@ -49,13 +49,13 @@
 
     <mat-autocomplete #autoComplete="matAutocomplete">
         <mat-option>
-            <mat-checkbox [checked]="isAllSelected" (change)="toggleSelectAll()" (click)="$event.stopPropagation()">
+            <mat-checkbox color="primary" [checked]="isAllSelected" (change)="toggleSelectAll()" (click)="$event.stopPropagation()">
                 {{'common.selectAll' | translate}}
             </mat-checkbox>
         </mat-option>
         <mat-option *ngFor="let item of filteredItems" [value]="selectedItems">
             <div (click)="optionClicked($event, item);">
-                <mat-checkbox [checked]="item.selected" (change)="toggleSelection(item)"
+                <mat-checkbox color="primary" [checked]="item.selected" (change)="toggleSelection(item)"
                     (click)="$event.stopPropagation()">
                     {{ item.preName + ' ' + item.name }}
                 </mat-checkbox>

--- a/frontend/src/app/organizations/organizations-list/organizations-list.component.html
+++ b/frontend/src/app/organizations/organizations-list/organizations-list.component.html
@@ -21,13 +21,13 @@
     <mat-table id="tableOrganization" #table [dataSource]="dataSource">
         <ng-container matColumnDef="Icon">
             <mat-header-cell *matHeaderCellDef>
-                <mat-checkbox [checked]="isAllSelected" (change)="changeSelectionAll()"></mat-checkbox>
+                <mat-checkbox color="primary" [checked]="isAllSelected" (change)="changeSelectionAll()"></mat-checkbox>
             </mat-header-cell>
             <mat-cell *matCellDef="let element" (mouseover)="mouseOver(element.id)">
                 <div *ngIf="!isSelectedRow(element.id)" class="selection">
                     {{element.name.substring(0,2)}}
                 </div>
-                <mat-checkbox class="checkBox" *ngIf="isSelectedRow(element.id)"
+                <mat-checkbox color="primary" class="checkBox" *ngIf="isSelectedRow(element.id)"
                     [checked]="isSelectionChecked(element.id)" (change)="onCheckBoxChecked(element.id)">
                 </mat-checkbox>
             </mat-cell>

--- a/frontend/src/assets/i18n/de.json
+++ b/frontend/src/assets/i18n/de.json
@@ -124,7 +124,7 @@
         "hidePast": "Veranstaltungen aus der Vergangenheit ausblenden",
         "edit": "Veranstaltung bearbeiten",
         "show": "Veranstaltungsinformationen anzeigen",
-        "info": "Veranstaltungsinformationen",
+        "info": "Übersicht",
         "delete": "Veranstaltung löschen",
         "invitation": "Einladen",
         "notInvited": "Nicht eingeladen",

--- a/frontend/src/assets/i18n/en.json
+++ b/frontend/src/assets/i18n/en.json
@@ -124,7 +124,7 @@
         "hidePast": "Hide events from the past",
         "edit": "Edit Event",
         "show": "Show Event Information",
-        "info": "Event Information",
+        "info": "Overview",
         "delete": "Delete Event",
         "invitation": "Invite",
         "notInvited": "Not invited",


### PR DESCRIPTION
Nun ist das editierfenster von den veranstaltungen weng höher, alle checkboxen sind nun ebenfalls blau, nicht mehr pink und einen darstellungsfehler im kalender behoben (das mit der minuten anzeige soll lt. markus nicht berücksichtigt werden, da ohnehin bald noch der endzeitpunkt mit rein kommen soll)