### PR TITLE
Fix extra quotation mark in placeholder

### DIFF
--- a/frontend/src/app/events/events-add/events-add.component.html
+++ b/frontend/src/app/events/events-add/events-add.component.html
@@ -12,7 +12,7 @@
         </div>
         <div class="col-md-3">
             <mat-form-field>
-                <textarea matInput placeholder="{{'common.description' | translate }}'" formControlName="description"></textarea>
+                <textarea matInput placeholder="{{'common.description' | translate }}" formControlName="description"></textarea>
             </mat-form-field>
         </div>
         <div class="col-md-3">


### PR DESCRIPTION
Falsches Anführungszeichen hinter der Beschreibung beim Erstellen eines Events behoben: 
![image](https://user-images.githubusercontent.com/60063612/102645721-36175a80-4163-11eb-999f-51108d97a434.png)
