### PR TITLE
ram_fixed smaller things

### DIFF
--- a/backend/WebApi/Controllers/ContactController.cs
+++ b/backend/WebApi/Controllers/ContactController.cs
@@ -68,6 +68,7 @@ namespace WebApi.Controllers
             return Ok(contactsDto);
         }
 
+        [Authorize(Roles = "Einsehen und Bearbeiten aller Kontakte")]
         [HttpGet("{id}")]
         [SwaggerResponse(HttpStatusCode.OK, typeof(ContactDto), Description = "successfully found")]
         [SwaggerResponse(HttpStatusCode.NotFound, typeof(void), Description = "contact not found")]
@@ -208,7 +209,7 @@ namespace WebApi.Controllers
             return Ok();
         }
 
-        [Authorize(Roles = "Einsehen und Bearbeiten einer Veranstaltung")]
+        [Authorize(Roles = "Einsehen und Bearbeiten aller Kontakte")]
         [HttpGet("{id}/history")]
         [SwaggerResponse(HttpStatusCode.OK, typeof(PagedResponse<List<object>>), Description = "successfully found")]
         public async Task<IActionResult> GetHistory(long id, [FromQuery] PaginationFilter filter)

--- a/frontend/src/app/contacts/contacts-add-dialog/contacts-add-dialog.component.ts
+++ b/frontend/src/app/contacts/contacts-add-dialog/contacts-add-dialog.component.ts
@@ -66,7 +66,7 @@ export class ContactsAddDialogComponent extends BaseDialogInput<ContactsAddDialo
 		this.contactsForm = this.fb.group({
 			name: ['', Validators.required],
 			preName: ['', Validators.required],
-			gender: [this.genderTypes[0], Validators.required],
+			gender: [this.genderTypes[0].type, Validators.required],
 			contactPartner: [''],
 			address: this.addressForm,
 			contactPossibilities: this.fb.group({

--- a/frontend/src/app/shared/osm/osm-address/osm-address.component.ts
+++ b/frontend/src/app/shared/osm/osm-address/osm-address.component.ts
@@ -106,8 +106,6 @@ export class OsmAddressComponent implements OnInit, ControlValueAccessor, Valida
   onSelection(selected: MatAutocompleteSelectedEvent) {
     const address: AddressDto = selected.option.value;
 
-    this.addressForm.reset();
-
     if (address.street) {
       this.addressForm.get('street').patchValue(address.street);
     }


### PR DESCRIPTION
nun wird das geschlecht männlich standartmäßig vorgewählt beim hinzufügen dialog von kontakten -> so kann der fehler im backend erst garnicht entstehen,
zusätzlich noch die erforderliche einzelberechtigung im backend für GetHistory auf "Einsehen und Bearbeiten von Kontakten" angepasst -> nun kommt kein backend fehler mehr wenn ich mit einem datenschutzfuzzi die infos eines kontakts einsehe und zu guter aller letzt werden nun die felder bei der adresssuche korrekt vordefiniert bei auswahl eines eintrags